### PR TITLE
Update Marisa ngram generation scripts

### DIFF
--- a/utils/ngramtxt2marisa.py
+++ b/utils/ngramtxt2marisa.py
@@ -62,7 +62,7 @@ with codecs.open(args.inputfile, encoding='utf-8') as f:
     for line in f:
         key, count = line.split('\t')
         count = int(count)
-        if count > args.threshold:
+        if count >= args.threshold:
             data[key] = count
             keyset.push_back(key)
             n = key.split()[0]

--- a/utils/ngramtxt2marisa.py
+++ b/utils/ngramtxt2marisa.py
@@ -112,7 +112,7 @@ agent = marisa.Agent()
 for k in data:
     agent.set_query(k)
     trie.lookup(agent)
-    arr[ agent.key_id() + 1 ] = data[k]
+    arr[ agent.key_id() + 1 ] = int(data[k] / factor)
 
 binwrite=open(os.path.join(args.output, 'ngrams.counts'),'wb')
 arr.tofile(binwrite)

--- a/utils/sqlite2marisa.py
+++ b/utils/sqlite2marisa.py
@@ -54,7 +54,7 @@ conn = sqlite3.connect(args.sqlite_input)
 db = conn.cursor()
 
 # get sum
-scount = db.execute("SELECT SUM(count) AS s FROM _1_gram WHERE count>?", (args.threshold,)).fetchone()[0]
+scount = db.execute("SELECT SUM(count) AS s FROM _1_gram WHERE count>=?", (args.threshold,)).fetchone()[0]
 if scount is None:
     scount = 1 # setting 1 as minimum
     
@@ -86,17 +86,17 @@ while cont:
 
     print('Loading n-gram:', ngram)
     print('Number of n-grams to load:',
-          db.execute("SELECT COUNT(*) AS s FROM " + tname + " WHERE count>?", (args.threshold,)).fetchone()[0])
+          db.execute("SELECT COUNT(*) AS s FROM " + tname + " WHERE count>=?", (args.threshold,)).fetchone()[0])
     print('Range of n-gram counts:',
-          db.execute("SELECT MAX(count) AS s FROM " + tname + " WHERE count>?", (args.threshold,)).fetchone()[0],
-          db.execute("SELECT MIN(count) AS s FROM " + tname + " WHERE count>?", (args.threshold,)).fetchone()[0])
+          db.execute("SELECT MAX(count) AS s FROM " + tname + " WHERE count>=?", (args.threshold,)).fetchone()[0],
+          db.execute("SELECT MIN(count) AS s FROM " + tname + " WHERE count>=?", (args.threshold,)).fetchone()[0])
     print()
           
     
     select = 'SELECT count,word'
     for i in range(ngram-1):
         select += ',word_%d' % (i+1)
-    select += ' FROM ' + tname + ' WHERE count>?'
+    select += ' FROM ' + tname + ' WHERE count>=?'
 
     for r in db.execute(select, (args.threshold,)):
         count = int(r[0]/factor)


### PR DESCRIPTION
Earlier version rejected ngrams with the given threshold. This PR updates Marisa ngram database generation scripts:

* forgotten normalization of Marisa database counts is added for ngramtxt2marisa

* threshold is used as a minimal allowed count 