### PR TITLE
Adds API for forgetting learned words

### DIFF
--- a/packaging/sailfish/presage.spec
+++ b/packaging/sailfish/presage.spec
@@ -142,6 +142,7 @@ cp -r packaging/sailfish/database_empty %{buildroot}%{_datadir}/presage/
 %doc AUTHORS ChangeLog NEWS README COPYING THANKS TODO
 %{_bindir}/presage_demo
 %{_bindir}/presage_demo_text
+%{_bindir}/presage_demo_forget
 %{_bindir}/presage_simulator
 %{_bindir}/text2ngram
 

--- a/src/lib/core/context_tracker/contextTracker.cpp
+++ b/src/lib/core/context_tracker/contextTracker.cpp
@@ -183,6 +183,19 @@ void ContextTracker::learn(const std::string& text) const
     }
 }
 
+void ContextTracker::forget(const std::string& word) const
+{
+    logger << INFO << "forget(): word: " << word << endl;
+
+    PredictorRegistry::Iterator it = predictorRegistry->iterator();
+    Predictor* predictor = 0;
+
+    while (it.hasNext()) {
+	predictor = it.next();
+	predictor->forget(word);
+    }
+}
+
 std::string ContextTracker::getPrefix() const
 {
     return getToken(0);

--- a/src/lib/core/context_tracker/contextTracker.h
+++ b/src/lib/core/context_tracker/contextTracker.h
@@ -197,6 +197,8 @@ public:
      */
     void learn(const std::string& text) const;
 
+    void forget(const std::string& word) const;
+
     virtual void update (const Observable* variable);
 
     void set_logger (const std::string& value);

--- a/src/lib/libpresage.map
+++ b/src/lib/libpresage.map
@@ -48,8 +48,10 @@ PRESAGE_0.9.2 {
 global:
 	extern "C++" {
 		Presage::version*;
+		Presage::forget*;
 	};
 	presage_version;
 	presage_predict_with_filter;
 	presage_free_prediction;
+	presage_forget;
 } PRESAGE_0.9.1;

--- a/src/lib/predictors/ARPAPredictor.cpp
+++ b/src/lib/predictors/ARPAPredictor.cpp
@@ -454,8 +454,6 @@ float ARPAPredictor::computeBigramBackoff(int wd1, int wd2) const
 
 void ARPAPredictor::learn(const std::vector<std::string>& change)
 {
-    logger << DEBUG << "learn() method called" << endl;
-    logger << DEBUG << "learn() method exited" << endl;
 }
 
 void ARPAPredictor::forget(const std::string& word)

--- a/src/lib/predictors/ARPAPredictor.cpp
+++ b/src/lib/predictors/ARPAPredictor.cpp
@@ -458,6 +458,10 @@ void ARPAPredictor::learn(const std::vector<std::string>& change)
     logger << DEBUG << "learn() method exited" << endl;
 }
 
+void ARPAPredictor::forget(const std::string& word)
+{
+}
+
 void ARPAPredictor::update (const Observable* var)
 {
     logger << DEBUG << "About to invoke dispatcher: " << var->get_name () << " - " << var->get_value() << endl;

--- a/src/lib/predictors/ARPAPredictor.h
+++ b/src/lib/predictors/ARPAPredictor.h
@@ -119,6 +119,8 @@ public:
 
     virtual void learn(const std::vector<std::string>& change);
 
+    virtual void forget(const std::string& word);
+
     virtual void update (const Observable* variable);
 
     void set_vocab_filename (const std::string& value);

--- a/src/lib/predictors/abbreviationExpansionPredictor.cpp
+++ b/src/lib/predictors/abbreviationExpansionPredictor.cpp
@@ -89,6 +89,11 @@ void AbbreviationExpansionPredictor::learn (const std::vector<std::string>& chan
     // intentionally empty
 }
 
+void AbbreviationExpansionPredictor::forget (const std::string& word)
+{
+    // intentionally empty
+}
+
 void AbbreviationExpansionPredictor::cacheAbbreviationsExpansions()
 {
     cache.clear();

--- a/src/lib/predictors/abbreviationExpansionPredictor.h
+++ b/src/lib/predictors/abbreviationExpansionPredictor.h
@@ -51,6 +51,8 @@ public:
 
     virtual void learn(const std::vector<std::string>& change);
 
+    virtual void forget(const std::string& word);
+
     virtual void update (const Observable* variable);
 
 private:

--- a/src/lib/predictors/dbconnector/databaseConnector.h
+++ b/src/lib/predictors/dbconnector/databaseConnector.h
@@ -92,7 +92,11 @@ public:
 
     /** Removes the ngram from the database
      */
-    void removeNgram(const Ngram ngram) const;
+    void removeNgram(const Ngram ngram);
+    
+    /** Removes ngrams containing the word from the database
+     */
+    void dropNgramsWithWord(const std::string &word);
 
     /** Marks the beginning of an SQL transaction.
      *

--- a/src/lib/predictors/dejavuPredictor.cpp
+++ b/src/lib/predictors/dejavuPredictor.cpp
@@ -132,6 +132,11 @@ void DejavuPredictor::learn(const std::vector<std::string>& change)
     }
 }
 
+void DejavuPredictor::forget(const std::string& word)
+{
+    // not implemented
+}
+
 /** Tests two list arguments match.
  *
  * @return true if lists contain the same tokens in the same order,

--- a/src/lib/predictors/dejavuPredictor.h
+++ b/src/lib/predictors/dejavuPredictor.h
@@ -50,6 +50,8 @@ public:
 
     virtual void learn(const std::vector<std::string>& change);
 
+    virtual void forget(const std::string& word);
+
     virtual void update (const Observable* variable);
 
 private:

--- a/src/lib/predictors/dictionaryPredictor.cpp
+++ b/src/lib/predictors/dictionaryPredictor.cpp
@@ -105,6 +105,12 @@ void DictionaryPredictor::learn(const std::vector<std::string>& change)
     std::cout << "DictionaryPredictor::learn() method exited" << std::endl;
 }
 
+void DictionaryPredictor::forget(const std::string& word)
+{
+    std::cout << "DictionaryPredictor::forget() method called" << std::endl;
+    std::cout << "DictionaryPredictor::forget() method exited" << std::endl;
+}
+
 void DictionaryPredictor::update (const Observable* var)
 {
     logger << DEBUG << "About to invoke dispatcher: " << var->get_name () << " - " << var->get_value() << endl;

--- a/src/lib/predictors/dictionaryPredictor.cpp
+++ b/src/lib/predictors/dictionaryPredictor.cpp
@@ -101,14 +101,10 @@ Prediction DictionaryPredictor::predict(const size_t max_partial_predictions_siz
 
 void DictionaryPredictor::learn(const std::vector<std::string>& change)
 {
-    std::cout << "DictionaryPredictor::learn() method called" << std::endl;
-    std::cout << "DictionaryPredictor::learn() method exited" << std::endl;
 }
 
 void DictionaryPredictor::forget(const std::string& word)
 {
-    std::cout << "DictionaryPredictor::forget() method called" << std::endl;
-    std::cout << "DictionaryPredictor::forget() method exited" << std::endl;
 }
 
 void DictionaryPredictor::update (const Observable* var)

--- a/src/lib/predictors/dictionaryPredictor.h
+++ b/src/lib/predictors/dictionaryPredictor.h
@@ -46,6 +46,8 @@ public:
 
     virtual void learn (const std::vector<std::string>& change);
 
+    virtual void forget(const std::string& word);
+
     virtual void update (const Observable* variable);
 
     void set_dictionary (const std::string& value);

--- a/src/lib/predictors/dummyPredictor.cpp
+++ b/src/lib/predictors/dummyPredictor.cpp
@@ -75,3 +75,9 @@ void DummyPredictor::learn(const std::vector<std::string>& change)
     std::cout << "DummyPredictor::learn() method called" << std::endl;
     std::cout << "DummyPredictor::learn() method exited" << std::endl;
 }
+
+void DummyPredictor::forget(const std::string& word)
+{
+    std::cout << "DummyPredictor::forget() method called" << std::endl;
+    std::cout << "DummyPredictor::forget() method exited" << std::endl;
+}

--- a/src/lib/predictors/dummyPredictor.cpp
+++ b/src/lib/predictors/dummyPredictor.cpp
@@ -72,12 +72,8 @@ Prediction DummyPredictor::predict(const size_t max_partial_predictions_size, co
 
 void DummyPredictor::learn(const std::vector<std::string>& change)
 {
-    std::cout << "DummyPredictor::learn() method called" << std::endl;
-    std::cout << "DummyPredictor::learn() method exited" << std::endl;
 }
 
 void DummyPredictor::forget(const std::string& word)
 {
-    std::cout << "DummyPredictor::forget() method called" << std::endl;
-    std::cout << "DummyPredictor::forget() method exited" << std::endl;
 }

--- a/src/lib/predictors/dummyPredictor.h
+++ b/src/lib/predictors/dummyPredictor.h
@@ -40,6 +40,8 @@ public:
 
     virtual void learn(const std::vector<std::string>& change);
 
+    virtual void forget(const std::string& word);
+
 private:
 	
 };

--- a/src/lib/predictors/hunspellPredictor.cpp
+++ b/src/lib/predictors/hunspellPredictor.cpp
@@ -132,6 +132,10 @@ void HunspellPredictor::learn(const std::vector<std::string>& change)
 {
 }
 
+void HunspellPredictor::forget(const std::string& word)
+{
+}
+
 void HunspellPredictor::update (const Observable* var)
 {
     logger << DEBUG << "About to invoke dispatcher: " << var->get_name () << " - " << var->get_value() << endl;

--- a/src/lib/predictors/hunspellPredictor.h
+++ b/src/lib/predictors/hunspellPredictor.h
@@ -49,6 +49,8 @@ public:
 
     virtual void learn (const std::vector<std::string>& change);
 
+    virtual void forget(const std::string& word);
+
     virtual void update (const Observable* variable);
 
     void set_dictionary_base (const std::string& value);

--- a/src/lib/predictors/predictor.h
+++ b/src/lib/predictors/predictor.h
@@ -62,6 +62,8 @@ public:
 
     virtual void learn(const std::vector<std::string>& change) = 0;
 
+    virtual void forget(const std::string& word) = 0;
+
     const std::string getName() const;
     const std::string getShortDescription() const;
     const std::string getLongDescription() const;

--- a/src/lib/predictors/recencyPredictor.cpp
+++ b/src/lib/predictors/recencyPredictor.cpp
@@ -124,10 +124,12 @@ Prediction RecencyPredictor::predict (const size_t max, const char** filter) con
 }
 
 void RecencyPredictor::learn(const std::vector<std::string>& change)
-{}
+{
+}
 
 void RecencyPredictor::forget(const std::string& word)
-{}
+{
+}
 
 void RecencyPredictor::update (const Observable* var)
 {

--- a/src/lib/predictors/recencyPredictor.cpp
+++ b/src/lib/predictors/recencyPredictor.cpp
@@ -126,6 +126,9 @@ Prediction RecencyPredictor::predict (const size_t max, const char** filter) con
 void RecencyPredictor::learn(const std::vector<std::string>& change)
 {}
 
+void RecencyPredictor::forget(const std::string& word)
+{}
+
 void RecencyPredictor::update (const Observable* var)
 {
     logger << DEBUG << "About to invoke dispatcher: " << var->get_name () << " - " << var->get_value() << endl;

--- a/src/lib/predictors/recencyPredictor.h
+++ b/src/lib/predictors/recencyPredictor.h
@@ -70,6 +70,8 @@ public:
 
     virtual void learn (const std::vector<std::string>& change);
 
+    virtual void forget(const std::string& word);
+
     virtual void update (const Observable* variable);
 
 private:

--- a/src/lib/predictors/smoothedNgramPredictor.cpp
+++ b/src/lib/predictors/smoothedNgramPredictor.cpp
@@ -24,6 +24,8 @@
 
 #include "smoothedNgramPredictor.h"
 
+#include "../core/utility.h"
+
 #include <sstream>
 #include <algorithm>
 
@@ -506,6 +508,25 @@ void SmoothedNgramPredictor::check_learn_consistency(const Ngram& ngram) const
 	    logger << DEBUG << "consistency adjusted" << endl;
 	}
     }
+}
+
+void SmoothedNgramPredictor::forget(const std::string& word)
+{
+    logger << INFO << "forget(\"" << word << "\")" << endl;
+
+    if (learn_mode) {
+	// learning is turned on
+        db->beginTransaction();
+        db->dropNgramsWithWord(word);
+
+        std::string word_normalized = Utility::strtolower(word);
+        if (word_normalized != word)
+            db->dropNgramsWithWord(word_normalized);
+        
+        db->endTransaction();
+    }
+    
+    logger << DEBUG << "end forget()" << endl;
 }
 
 void SmoothedNgramPredictor::update (const Observable* var)

--- a/src/lib/predictors/smoothedNgramPredictor.h
+++ b/src/lib/predictors/smoothedNgramPredictor.h
@@ -53,6 +53,8 @@ public:
 
     virtual void learn(const std::vector<std::string>& change);
 
+    virtual void forget(const std::string& word);
+
     virtual void update (const Observable* variable);
 
 private:

--- a/src/lib/predictors/smoothedNgramTriePredictor.cpp
+++ b/src/lib/predictors/smoothedNgramTriePredictor.cpp
@@ -321,6 +321,10 @@ void SmoothedNgramTriePredictor::learn(const std::vector<std::string>& change)
   logger << INFO << "learn(\"" << ngram_to_string(change) << "\") not implemented for SmoothedNgramTriePredictor" << endl;
 }
 
+void SmoothedNgramTriePredictor::forget(const std::string& word)
+{
+  logger << INFO << "forget(\"" << word << "\") not implemented for SmoothedNgramTriePredictor" << endl;
+}
 
 void SmoothedNgramTriePredictor::update (const Observable* var)
 {

--- a/src/lib/predictors/smoothedNgramTriePredictor.cpp
+++ b/src/lib/predictors/smoothedNgramTriePredictor.cpp
@@ -318,12 +318,10 @@ Prediction SmoothedNgramTriePredictor::predict(const size_t max_partial_predicti
 
 void SmoothedNgramTriePredictor::learn(const std::vector<std::string>& change)
 {
-  logger << INFO << "learn(\"" << ngram_to_string(change) << "\") not implemented for SmoothedNgramTriePredictor" << endl;
 }
 
 void SmoothedNgramTriePredictor::forget(const std::string& word)
 {
-  logger << INFO << "forget(\"" << word << "\") not implemented for SmoothedNgramTriePredictor" << endl;
 }
 
 void SmoothedNgramTriePredictor::update (const Observable* var)

--- a/src/lib/predictors/smoothedNgramTriePredictor.h
+++ b/src/lib/predictors/smoothedNgramTriePredictor.h
@@ -47,6 +47,9 @@ public:
   // no-op
   virtual void learn(const std::vector<std::string>& change);
 
+  // no-op
+  virtual void forget(const std::string& word);
+
   virtual void update (const Observable* variable);
 
 protected:

--- a/src/lib/presage.cpp
+++ b/src/lib/presage.cpp
@@ -143,6 +143,12 @@ void Presage::learn(const std::string text) const
 				 // learn to specify offline learning
 }
 
+void Presage::forget(const std::string word) const
+    throw (PresageException)
+{
+    contextTracker->forget(word);
+}
+
 PresageCallback* Presage::callback (PresageCallback* callback)
     throw (PresageException)
 {
@@ -464,6 +470,14 @@ presage_error_code_t presage_learn (presage_t prsg, const char* text)
     presage_exception_handler
     (
 	prsg->presage_object->learn (text);
+    );
+}
+
+presage_error_code_t presage_forget (presage_t prsg, const char* text)
+{
+    presage_exception_handler
+    (
+	prsg->presage_object->forget (text);
     );
 }
 

--- a/src/lib/presage.h
+++ b/src/lib/presage.h
@@ -169,6 +169,17 @@ public:
      */
     void learn(const std::string text) const throw (PresageException);
 
+    /** \brief Forget a word.
+     *
+     * Requests presage to forget a \param word. The active predictors
+     * in presage that are able to learn from text, are also able to
+     * forget the words.
+     *
+     * \param text a text string to learn from.
+     *
+     */
+    void forget(const std::string word) const throw (PresageException);
+
     /** \brief Callback getter/setter.
      *
      * \param callback to be used by presage (pass a null pointer to
@@ -314,6 +325,9 @@ extern "C" {
                                                       presage_prediction_t* result);
     
     presage_error_code_t presage_learn               (presage_t prsg,
+						      const char* text);
+
+    presage_error_code_t presage_forget              (presage_t prsg,
 						      const char* text);
 
     presage_error_code_t presage_completion          (presage_t prsg,

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -27,6 +27,7 @@ noinst_LTLIBRARIES =	libtools.la
 libtools_la_SOURCES =	ngram.cpp ngram.h
 
 bin_PROGRAMS =		presage_demo_text \
+			presage_demo_forget \
 			presage_simulator
 
 if USE_SQLITE
@@ -49,6 +50,9 @@ endif
 
 presage_demo_text_SOURCES = 	presageDemoText.cpp
 presage_demo_text_LDADD = 	../lib/libpresage.la
+
+presage_demo_forget_SOURCES = 	presageDemoForget.cpp
+presage_demo_forget_LDADD = 	../lib/libpresage.la
 
 presage_simulator_SOURCES =	presageSimulator.cpp
 presage_simulator_LDADD =	simulator/libsimulator.la \

--- a/src/tools/presageDemoForget.cpp
+++ b/src/tools/presageDemoForget.cpp
@@ -1,0 +1,157 @@
+
+/******************************************************
+ *  Presage, an extensible predictive text entry system
+ *  ---------------------------------------------------
+ *
+ *  Copyright (C) 2008  Matteo Vescovi <matteo.vescovi@yahoo.co.uk>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+                                                                             *
+                                                                **********(*)*/
+
+
+#include "presage.h"
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#ifdef HAVE_STDLIB_H
+# include <stdlib.h>
+#endif
+
+#include <getopt.h>
+
+#include <iostream>
+#include <sstream>
+
+const char PROGRAM_NAME[] = "presage_demo_forget";
+
+void disclaimer ();
+void parse_cmd_line_args (int argc, char** argv);
+void print_version ();
+void print_usage ();
+void print_prediction (const std::vector<std::string>&);
+
+std::string config;
+std::string word;
+
+int main(int argc, char** argv)
+{
+    parse_cmd_line_args (argc, argv);
+    disclaimer ();
+
+    // magic starts here...
+    LegacyPresageCallback callback;
+    Presage presage (&callback, config);
+
+    if (word.empty()) {
+      std::cerr << "Word to forget is not specified\n";
+      return -1;
+    }
+
+    presage.forget(word);
+
+    std::cout << "Word " << word << " forgotten\n";
+    return 0;
+}
+
+
+void disclaimer ()
+{
+    std::cout <<
+        "Presage Forget Demo\n"
+        "--------------------\n"
+        "\n"
+        "This program is intended as a demonstration of Presage ONLY.\n"
+        "\n"
+        "The Presage project aims to provide an intelligent predictive text entry platform.\n"
+        "\n"
+        "Its intent is NOT to provide a predictive text entry user interface.\n"
+        "Think of Presage as the predictive backend that sits behind a shiny user interface and does all the predictive heavy lifting.\n"
+        "\n" << std::endl;
+}
+
+void parse_cmd_line_args (int argc, char* argv[])
+{
+    int next_option;
+
+    // getopt structures
+    const char* const short_options = "c:w:hv";
+
+    const struct option long_options[] = {
+	{ "config",       required_argument, 0, 'c' },
+	{ "word",         required_argument, 0, 'w' },
+	{ "help",         no_argument,       0, 'h' },
+	{ "version",      no_argument,       0, 'v' },
+	{ 0, 0, 0, 0 }
+    };
+
+    do {
+        next_option = getopt_long( argc, argv, 
+                                   short_options, long_options, NULL );
+
+        switch( next_option ) {
+	case 'c': // --config or -c option
+            config = optarg;
+            break;
+	case 'w': // --word or -w option
+            word = optarg;
+	    break;
+	case 'h': // --help or -h option
+	    print_usage ();
+	    exit (0);
+	    break;
+	case 'v': // --version or -v option
+	    print_version ();
+	    exit (0);
+	    break;
+	case '?': // unknown option
+	    print_usage();
+	    exit (0);
+	    break;
+	case -1:
+	    break;
+	default:
+	    abort ();
+	    break;
+	}
+
+    } while (next_option != -1);
+}
+
+void print_version ()
+{
+    std::cout << PROGRAM_NAME << " (" << PACKAGE << ") version " << VERSION << std::endl
+              << "Copyright (C) 2004 Matteo Vescovi." << std::endl
+              << "This is free software; see the source for copying conditions.  There is NO" << std::endl
+              << "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE," << std::endl
+              << "to the extent permitted by law." << std::endl;
+}
+
+void print_usage ()
+{
+    std::cout << "Usage: " << PROGRAM_NAME << " [OPTION]..." << std::endl
+              << std::endl
+              << "At the prompt, type in some text. Hit enter to generate a prediction." << std::endl
+              << "Any text input is valid, including no text, a single character, or a long string." << std::endl
+              << std::endl
+              << "  -c, --config CONFIG  use config file CONFIG" << std::endl
+              << "  -w, --word W         word to forget" << std::endl
+              << "  -h, --help           display this help and exit" << std::endl
+              << "  -v, --version        output version information and exit" << std::endl
+              << std::endl
+              << "Direct your bug reports to: " << PACKAGE_BUGREPORT << std::endl;
+}

--- a/src/tools/presageDemoForget.cpp
+++ b/src/tools/presageDemoForget.cpp
@@ -4,6 +4,7 @@
  *  ---------------------------------------------------
  *
  *  Copyright (C) 2008  Matteo Vescovi <matteo.vescovi@yahoo.co.uk>
+ *  Copyright (C) 2018  rinigus <rinigus.git@gmail.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Fixes: https://github.com/sailfish-keyboard/presage/issues/19

Through method `forget`, a word can be given that will be forgotten by all actively learning predictors. In practice, its implemented for smoothedNgramPredictor only since the other predictors are either not learning or hard to use in practice (`DejavuPredictor`) on mobile devices due to the heavy resource consumption.

In the implementation, the given word is searched for in all n-grams (any of the words) and the corresponding n-grams are removed. This is done for word as given (case sensitive) as well as normalized version (at present we use lowercasing, this will change with Unicode, will have adjust `forget` method of the predictor). 

As a limitation, word is not deleted from predictors that have learning disabled (files are either readonly or predictor doesn't support write operations, as for Marisa).