### PR TITLE
Fix compilation with gcc-12

### DIFF
--- a/src/lib/presage.cpp
+++ b/src/lib/presage.cpp
@@ -31,7 +31,7 @@
 #include "core/predictorActivator.h"
 
 Presage::Presage (PresageCallback* callback)
-    throw (PresageException)
+    noexcept(false)
 {
     profileManager = new ProfileManager();
     configuration = profileManager->get_configuration();
@@ -42,7 +42,7 @@ Presage::Presage (PresageCallback* callback)
 }
 
 Presage::Presage (PresageCallback* callback, const std::string config_filename)
-    throw (PresageException)
+    noexcept(false)
 {
     profileManager = new ProfileManager(config_filename);
     configuration = profileManager->get_configuration();
@@ -62,7 +62,7 @@ Presage::~Presage()
 }
 
 std::vector<std::string> Presage::predict ()
-    throw (PresageException)
+    noexcept(false)
 {
     std::vector<std::string> result;
 
@@ -88,7 +88,7 @@ std::vector<std::string> Presage::predict ()
 }
 
 std::multimap<double, std::string> Presage::predict (std::vector<std::string> filter)
-    throw (PresageException)
+    noexcept(false)
 {
     std::multimap<double, std::string> result;
 
@@ -137,26 +137,26 @@ std::multimap<double, std::string> Presage::predict (std::vector<std::string> fi
 }
 
 void Presage::learn(const std::string text) const
-    throw (PresageException)
+    noexcept(false)
 {
     contextTracker->learn(text); // TODO: can pass additional param to
 				 // learn to specify offline learning
 }
 
 void Presage::forget(const std::string word) const
-    throw (PresageException)
+    noexcept(false)
 {
     contextTracker->forget(word);
 }
 
 PresageCallback* Presage::callback (PresageCallback* callback)
-    throw (PresageException)
+    noexcept(false)
 {
     return const_cast<PresageCallback*>(contextTracker->callback(callback));
 }
 
 std::string Presage::completion (const std::string str)
-    throw (PresageException)
+    noexcept(false)
 {
     // There are two types of completions: normal and erasing.
     // normal_completion  = prefix + remainder
@@ -204,43 +204,43 @@ std::string Presage::completion (const std::string str)
 }
 
 std::string Presage::context () const
-    throw (PresageException)
+    noexcept(false)
 {
     return contextTracker->getPastStream();
 }
 
 bool Presage::context_change () const
-    throw (PresageException)
+    noexcept(false)
 {
     return contextTracker->contextChange();
 }
 
 std::string Presage::prefix () const
-    throw (PresageException)
+    noexcept(false)
 {
     return contextTracker->getPrefix();
 }
 
 std::string Presage::config (const std::string variable) const
-    throw (PresageException)
+    noexcept(false)
 {
     return configuration->find (variable)->get_value ();
 }
 
 void Presage::config (const std::string variable, const std::string value) const
-    throw (PresageException)
+    noexcept(false)
 {
     configuration->insert (variable, value);
 }
 
 void Presage::save_config () const
-    throw (PresageException)
+    noexcept(false)
 {
     profileManager->save_profile ();
 }
 
 std::string Presage::version () const
-    throw (PresageException)
+    noexcept(false)
 {
     return VERSION;
 }

--- a/src/lib/presage.h
+++ b/src/lib/presage.h
@@ -112,7 +112,7 @@ public:
      * 
      * Presage does not take ownership of the callback object.
      */
-    Presage(PresageCallback* callback) throw (PresageException);
+    Presage(PresageCallback* callback) noexcept(false);
 
 
     /** Creates and initializes presage with supplied configuration.
@@ -122,7 +122,7 @@ public:
      *
      * Presage does not take ownership of the callback object.
      */
-    Presage(PresageCallback* callback, const std::string config) throw (PresageException);
+    Presage(PresageCallback* callback, const std::string config) noexcept(false);
 
 
     /** Destroys presage.
@@ -138,7 +138,7 @@ public:
      * context.
      *
      */
-    std::vector<std::string> predict() throw (PresageException);
+    std::vector<std::string> predict() noexcept(false);
 
     /** \brief Obtain a prediction that matches the supplied token
      *         filter.
@@ -153,7 +153,7 @@ public:
      * of the filter tokens.
      *
      */
-    std::multimap<double, std::string> predict(std::vector<std::string> filter) throw (PresageException);
+    std::multimap<double, std::string> predict(std::vector<std::string> filter) noexcept(false);
 
     /** \brief Learn from text offline.
      *
@@ -167,7 +167,7 @@ public:
      * \param text a text string to learn from.
      *
      */
-    void learn(const std::string text) const throw (PresageException);
+    void learn(const std::string text) const noexcept(false);
 
     /** \brief Forget a word.
      *
@@ -178,7 +178,7 @@ public:
      * \param text a text string to learn from.
      *
      */
-    void forget(const std::string word) const throw (PresageException);
+    void forget(const std::string word) const noexcept(false);
 
     /** \brief Callback getter/setter.
      *
@@ -187,7 +187,7 @@ public:
      *
      * \return pointer to previously used callback
      */
-    PresageCallback* callback(PresageCallback* callback) throw (PresageException);
+    PresageCallback* callback(PresageCallback* callback) noexcept(false);
 
     /** \brief Request presage to return the completion string for the given predicted token.
      *
@@ -201,26 +201,26 @@ public:
      *
      * \return completion string
      */
-    std::string completion(std::string str) throw (PresageException);
+    std::string completion(std::string str) noexcept(false);
 
     /** \brief Returns the text entered so far.
      *
      * \return context, text entered so far.
      */
-    std::string context() const throw (PresageException);
+    std::string context() const noexcept(false);
 
     /** \brief Returns true if a context change occured.
      *
      * \return true if a context change occured after the last update
      * or predict calls, or false otherwise.
      */
-    bool context_change() const throw (PresageException);
+    bool context_change() const noexcept(false);
 
     /** \brief Returns the current prefix.
      *
      * \return prefix
      */
-    std::string prefix() const throw (PresageException);
+    std::string prefix() const noexcept(false);
 
     /** \brief Gets the value of specified configuration variable.
      *
@@ -229,7 +229,7 @@ public:
      *
      * \return value assigned to configuration variable.
      */
-    std::string config(const std::string variable) const throw (PresageException);
+    std::string config(const std::string variable) const noexcept(false);
 
     /** \brief Sets the value of specified configuration variable.
      *
@@ -238,7 +238,7 @@ public:
      * from the configuration file in use.
      *
      */
-    void config(const std::string variable, const std::string value) const throw (PresageException);
+    void config(const std::string variable, const std::string value) const noexcept(false);
 
     /** \brief Save current configuration to file.
      *
@@ -247,14 +247,14 @@ public:
      * active XML profile.
      *
      */
-    void save_config() const throw (PresageException);
+    void save_config() const noexcept(false);
 
     /** \brief Returns presage release version.
      *
      * Programmatically retrieve the presage release version string.
      *
      */
-    std::string version() const throw (PresageException);
+    std::string version() const noexcept(false);
 
     /*
      * Presage public API ends here


### PR DESCRIPTION
gcc-12 defaults to C++17.  We don't lower the C++ standard as the package installs a public header.

This is based on a patch by Simon Chopin for the Debian package.