### PR TITLE
Text2ngram character class improvments

### DIFF
--- a/src/tools/text2ngram.cpp
+++ b/src/tools/text2ngram.cpp
@@ -174,7 +174,7 @@ int main(int argc, char* argv[])
 	std::ifstream infile(argv[i]);
 	ForwardTokenizer tokenizer(infile,
 				   " \f\n\r\t\v",
-				   "`~!@#$%^&*()_-+=\\|]}[{'\";:/?.>,<");
+				   "`~!@#$%^&*()_-+=\\|]}[{'\";:/?.>,<«»");
 	tokenizer.lowercaseMode(lowercase);
 
 	// take care of first N-1 tokens

--- a/src/tools/text2ngram.cpp
+++ b/src/tools/text2ngram.cpp
@@ -173,7 +173,7 @@ int main(int argc, char* argv[])
 	// create tokenizer object and open input file stream
 	std::ifstream infile(argv[i]);
 	ForwardTokenizer tokenizer(infile,
-				   " \f\n\r\t\v",
+				   " \f\n\r\t\v ",
 				   "`~!@#$%^&*()_-+=\\|]}[{'\";:/?.>,<«»");
 	tokenizer.lowercaseMode(lowercase);
 


### PR DESCRIPTION
Add nonbreaking space to separators and `»«` to separators. 

The approach taken in utils/ is nicer but having `text2ngram` do the right thing helps for sqlite based DBs.