### PR TITLE
Use version 2.0.0 in autoconf and symbol versions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ dnl 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 dnl Process this file with autoconf to produce a configure script.
 
 
-AC_INIT([presage],[0.9.2~beta],[https://github.com/sailfish-keyboard/presage])
+AC_INIT([presage],[2.0.0],[https://github.com/sailfish-keyboard/presage])
 AM_INIT_AUTOMAKE([1.9 tar-ustar -Wall])
 
 AC_CONFIG_SRCDIR([src/lib/presage.cpp])

--- a/src/lib/libpresage.map
+++ b/src/lib/libpresage.map
@@ -44,7 +44,7 @@ global:
 	presage_learn;
 } PRESAGE_0.8.5;
 
-PRESAGE_0.9.2 {
+PRESAGE_2.0.0 {
 global:
 	extern "C++" {
 		Presage::version*;


### PR DESCRIPTION
The forget API was marked as introduced in version 0.9.2 in `src/lib/libpresage.map`, but it looks like this version was never released. This changes the symbol versions to 2.0.0. I only noticed this because Debian linters are rather picky about symbol versions matching release versions. Not sure if there are released packages somewhere (like in SailfishOS) with the previous symbol map and how this change affects them.

Also changes the project version to 2.0.0 in `configure.ac`.