### PR TITLE
Add pkg-config file presage.pc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -63,6 +63,10 @@ dirs.h:	Makefile
 
 EXTRA_DIST =	FAQ
 
+# Install the pkg-config file; the directory is set using
+# PKG_INSTALLDIR in configure.ac.
+pkgconfig_DATA = src/lib/presage.pc
+
 # Ensure local m4 macros are included during autoreconf and automatic
 # aclocal.m4 remaking
 ACLOCAL_AMFLAGS = -I m4

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,9 @@ dnl Process this file with autoconf to produce a configure script.
 AC_INIT([presage],[2.0.0],[https://github.com/sailfish-keyboard/presage])
 AM_INIT_AUTOMAKE([1.9 tar-ustar -Wall])
 
+dnl Define install directory for pkg-config files
+PKG_INSTALLDIR
+
 AC_CONFIG_SRCDIR([src/lib/presage.cpp])
 AC_CONFIG_HEADERS([config.h:config.hin])
 AC_CONFIG_MACRO_DIR([m4])
@@ -567,6 +570,7 @@ AC_CONFIG_FILES([
 	Makefile
 	src/Makefile
 	src/lib/Makefile
+	src/lib/presage.pc
 	src/lib/core/Makefile
 	src/lib/core/tokenizer/Makefile
 	src/lib/core/context_tracker/Makefile

--- a/src/lib/presage.pc.in
+++ b/src/lib/presage.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: presage
+Description: Predictive text entry system
+URL: https://github.com/sailfish-keyboard/presage
+Version: @VERSION@
+Requires:
+Libs: -L${libdir} -lpresage
+Cflags: -I${includedir}


### PR DESCRIPTION
Add a pkg-config file to make it easier to detect presage version on build-time.